### PR TITLE
feat: make .update() method can update without embedding

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -120,10 +120,12 @@ export class EmbeddingIndex {
     if (index === -1) {
       throw new Error('Vector not found');
     }
-    // Validate and add the new vector
-    this.validateAndAdd(vector);
+    if (vector.hasOwnProperty('embedding')) {
+      // Validate and add the new vector
+      this.validateAndAdd(vector);
+    }
     // Replace the old vector with the new one
-    this.objects[index] = vector;
+    this.objects[index] = Object.assign(this.objects[index] as Filter, vector);
   }
 
   // Method to remove a vector from the index


### PR DESCRIPTION
Related to #9. Allow the `.update()` method to update only attributes other than embedding.

Also, I noticed that due to the fact that `findVectorIndex` only returns the first matching element, `.update()` will only update the first element, and the same situation occurs with `.get()`.
I believe this deviates from the original intention of the `Filter`. In at least the scenarios I've encountered, operations on vectors are typically batch-oriented. Therefore, it might be worth considering a method for the entire `EmbeddingIndex` to communicate and return in the form of array of vectors.